### PR TITLE
bintools: Add response file support to `ld-wrapper`

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -140,6 +140,7 @@ stdenv.mkDerivation {
         local dst="$1"
         local wrapper="$2"
         export prog="$3"
+        export use_response_file_by_default=${if (bintools.isCCTools or false) then "1" else "0"}
         substituteAll "$wrapper" "$out/bin/$dst"
         chmod +x "$out/bin/$dst"
       }

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -250,10 +250,18 @@ fi
 
 PATH="$path_backup"
 # Old bash workaround, see above.
-@prog@ \
-    ${extraBefore+"${extraBefore[@]}"} \
-    ${params+"${params[@]}"} \
-    ${extraAfter+"${extraAfter[@]}"}
+
+if (( "${NIX_LD_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
+    @prog@ @<(printf "%q\n" \
+        ${extraBefore+"${extraBefore[@]}"} \
+        ${params+"${params[@]}"} \
+        ${extraAfter+"${extraAfter[@]}"})
+else
+    @prog@ \
+        ${extraBefore+"${extraBefore[@]}"} \
+        ${params+"${params[@]}"} \
+        ${extraAfter+"${extraAfter[@]}"}
+fi
 
 if [ -e "@out@/nix-support/post-link-hook" ]; then
     source @out@/nix-support/post-link-hook

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -89,6 +89,7 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit targetPrefix;
+    isCCTools = true;
   };
 
   meta = {

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -3,6 +3,7 @@
 , libuuid
 , libobjc ? null, maloader ? null
 , enableTapiSupport ? true, libtapi
+, fetchpatch
 }:
 
 let
@@ -42,6 +43,14 @@ stdenv.mkDerivation {
   patches = [
     ./ld-ignore-rpath-link.patch
     ./ld-rpath-nonfinal.patch
+    (fetchpatch {
+      url = "https://github.com/tpoechtrager/cctools-port/commit/4a734070cd2838e49658464003de5b92271d8b9e.patch";
+      hash = "sha256-72KaJyu7CHXxJJ1GNq/fz+kW1RslO3UaKI91LhBtiXA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/MercuryTechnologies/cctools-port/commit/e1f2802ea4bfde6fe00d2d815303392b11a262eb.patch";
+      hash = "sha256-SWVUzFaJHH2fu9y8RcU3Nx/QKx60hPE5zFx0odYDeQs=";
+    })
   ]
     ++ lib.optional stdenv.isDarwin ./darwin-no-memstream.patch;
 


### PR DESCRIPTION
The motivation behind this is to alleviate the problem described in https://github.com/NixOS/nixpkgs/issues/41340. I'm not sure if this completely fixes the problem, but it eliminates one more area where we can exceed command line length limits.

This is essentially the same change as in #112449, except for `ld-wrapper.sh` instead of `cc-wrapper.sh`.

However, that change alone was not enough; on macOS the `ld` provided by `darwin.cctools` fails if you use process substitution to generate the response file, so I put up two PRs to fix that:

https://github.com/tpoechtrager/cctools-port/pull/131
https://github.com/tpoechtrager/cctools-port/pull/132

… and I included a patch referencing that fix so that the new `ld-wrapper` still works on macOS.