### PR TITLE
python3Packages.dnspython: fix tests (again)

### DIFF
--- a/pkgs/development/python-modules/dnspython/default.nix
+++ b/pkgs/development/python-modules/dnspython/default.nix
@@ -21,7 +21,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.optionals stdenv.isDarwin [
     cacert
   ];
 


### PR DESCRIPTION
The upstream PR is https://github.com/NixOS/nixpkgs/pull/218662

This is essentially the same fix as #161740, except not just for macOS.

The `dnspython` build was failing on Linux with a certificate verification failure just like in #161740:

```ShellSession
$ nix build nixpkgs#python3Packages.dnspython --rebuild
error: builder for '/nix/store/c1v553fzq3yybsd0lm398qf87jmy47qd-python3.10-dnspython-2.3.0.drv' failed with exit code 1;
       last 10 log lines:
       >
       > /nix/store/iw1vmh509hcbby8dbpsaanbri4zsq7dj-python3-3.10.10/lib/python3.10/ssl.py:1342: SSLCertVerificationError
…
```

… and this change fixes that build failure.

