### PR TITLE
proj: fix test suite

### DIFF
--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -12,6 +12,7 @@
 , gtest
 , nlohmann_json
 , python3
+, cacert
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -40,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   buildInputs = [ sqlite libtiff curl nlohmann_json ];
 
-  nativeCheckInputs = [ gtest ];
+  nativeCheckInputs = [ cacert gtest ];
 
   cmakeFlags = [
     "-DUSE_EXTERNAL_GTEST=ON"


### PR DESCRIPTION
Corresponding upstream PR: https://github.com/NixOS/nixpkgs/pull/218719

When testing #213831 internally we ran into a build failure caused by that change for the `proj` package (on `x86_64-linux`).  We're not sure how that's possible, but the nature of the build failure was that the network tests for the `proj` package were failing due to missing certificates, so I fixed the build failure by adding `cacert` as a test dependency.

It's still not clear (A) why the cert suddenly became necessary after the change in #213831 or (B) why the build worked at all before, but this is probably the right thing to do regardless because the test suite does have a network component.
