### PR TITLE
python310Packages.pytest-httpserver: Fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/pytest-httpserver/default.nix
+++ b/pkgs/development/python-modules/pytest-httpserver/default.nix
@@ -37,6 +37,12 @@ buildPythonPackage rec {
     toml
   ];
 
+  __darwinAllowLocalNetworking = true;
+
+  disabledTests = [
+    "test_wait_raise_assertion_false" # racy
+  ];
+
   pythonImportsCheck = [
     "pytest_httpserver"
   ];


### PR DESCRIPTION
Cherry-pick of https://github.com/NixOS/nixpkgs/commit/b5724354b7345329d5ba3aba04223a5655dc9304